### PR TITLE
fix: Delete overflow hidden and height 100vh

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,6 @@
   max-width: 400px;
   margin: 0 auto;
   background-color: white;
-  height: 100vh; /* 높이 지정 */
 }
 
 body {
@@ -10,7 +9,6 @@ body {
   padding: 0;
   box-sizing: border-box;
   background-color: gray;
-  overflow: hidden;
   height: 100%;
 }
 

--- a/src/pages/Piggybank.jsx
+++ b/src/pages/Piggybank.jsx
@@ -129,6 +129,7 @@ const Container = styled.div`
   justify-content: center;
   background-color: #fcfdf5;
   padding: 20px;
+  height: 100vh;
 `;
 
 const Title = styled.h2`

--- a/src/pages/Question/PastQuestionPage.jsx
+++ b/src/pages/Question/PastQuestionPage.jsx
@@ -49,6 +49,7 @@ function PastQuestionPage() {
           .past-question-page {
             padding: 1rem;
             background-color: #fcfdf5;
+            height: 100vh;
           }
           
           h3 {

--- a/src/pages/Question/TodayQuestionPage.jsx
+++ b/src/pages/Question/TodayQuestionPage.jsx
@@ -114,6 +114,7 @@ const TodayQuestionPage = () => {
             flex-direction: column;
             background-color: #f3f3f3;
             position: relative;
+            height: 100vh;
           }
 
           .question-card {


### PR DESCRIPTION
## #️⃣연관된 이슈

> SCRUM - 16

## 📝작업 내용

> fix: Delete overflow hidden and height 100vh
- Delete `overflow: hidden` and `height: 100vh`
- The reason for modifying `height: 100vh` is that applying `overflow: hidden` can cause the viewpoint to appear cut off.


<!-- 커밋 메시지 제목  -->
<!-- 커밋 메시지 본문  -->
<!-- 자유 설명  -->

## 💬리뷰 요구사항(선택)

> 없음

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- e.g) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?  -->

## 💬PR TYPE

<!-- "x"를 이용해서, 해당 타입에 체크해주세요. -->

- [x] Bugfix
- [ ] New Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
      infrastructure changes
- [ ] Other... Please describe:
